### PR TITLE
Fix media urls to use "main" branch

### DIFF
--- a/sleep.js
+++ b/sleep.js
@@ -50,12 +50,12 @@ var sleep = {
         this._video.style.left = '-10px';
 
         var source_mp4 = document.createElement('source');
-        source_mp4.setAttribute('src', 'https://github.com/ivanmaeder/computer-sleep/raw/master/resources/muted-blank.mp4');
+        source_mp4.setAttribute('src', 'https://github.com/ivanmaeder/computer-sleep/raw/main/resources/muted-blank.mp4');
         source_mp4.setAttribute('type', 'video/mp4');
         this._video.appendChild(source_mp4);
 
         var source_ogg = document.createElement('source');
-        source_ogg.setAttribute('src', 'https://github.com/ivanmaeder/computer-sleep/raw/master/resources/muted-blank.ogv');
+        source_ogg.setAttribute('src', 'https://github.com/ivanmaeder/computer-sleep/raw/main/resources/muted-blank.ogv');
         source_ogg.setAttribute('type', 'video/ogg');
         this._video.appendChild(source_ogg);
 


### PR DESCRIPTION
I was adapting the sleep.js file for my use case, and noticed that these urls were returning 404 errors. 

The issue is Github has switched from using "master" branch to "main" branch. Updated accordingly.

